### PR TITLE
load numerical features by default. name trees in grow()

### DIFF
--- a/applyforest/applyforest.go
+++ b/applyforest/applyforest.go
@@ -3,10 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/ryanbressler/CloudForest"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/lytics/CloudForest"
 )
 
 func main() {
@@ -125,7 +126,7 @@ func main() {
 		for i, box := range cbb.Box {
 			fmt.Fprintf(votefile, "%v", data.CaseLabels[i])
 
-			for j, _ := range cbb.CatMap.Back {
+			for j := range cbb.CatMap.Back {
 				total := 0.0
 				total = box.Map[j]
 

--- a/catmap.go
+++ b/catmap.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 /*CatMap is for mapping categorical values to integers.
 It contains:
 

--- a/densenumfeature.go
+++ b/densenumfeature.go
@@ -663,7 +663,7 @@ func (f *DenseNumFeature) CopyInTo(copyf Feature) {
 //ImputeMissing imputes the missing values in a feature to the mean or mode of the feature.
 func (f *DenseNumFeature) ImputeMissing() {
 	cases := make([]int, 0, len(f.Missing))
-	for i, _ := range f.Missing {
+	for i := range f.Missing {
 		cases = append(cases, i)
 	}
 	mean := 0.0

--- a/featureinterfaces.go
+++ b/featureinterfaces.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 const maxExhaustiveCats = 5
 const maxNonRandomExahustive = 10
 const maxNonBigCats = 30

--- a/featurematrix.go
+++ b/featurematrix.go
@@ -447,21 +447,7 @@ func LoadAFM(filename string) (fm *FeatureMatrix, err error) {
 func ParseFeature(record []string) Feature {
 	capacity := len(record)
 	switch record[0][0:2] {
-	case "N:":
-		f := &DenseNumFeature{
-			nil,
-			make([]bool, 0, capacity),
-			record[0],
-			false}
-		f.NumData = make([]float64, 0, capacity)
-
-		for i := 1; i < len(record); i++ {
-			f.Append(record[i])
-
-		}
-		return f
-
-	default:
+	case "C:":
 		f := &DenseCatFeature{
 			&CatMap{make(map[string]int, 0),
 				make([]string, 0, 0)},
@@ -476,6 +462,21 @@ func ParseFeature(record []string) Feature {
 
 		}
 		return f
+
+	default:
+		f := &DenseNumFeature{
+			nil,
+			make([]bool, 0, capacity),
+			record[0],
+			false}
+		f.NumData = make([]float64, 0, capacity)
+
+		for i := 1; i < len(record); i++ {
+			f.Append(record[i])
+		}
+
+		return f
+
 	}
 
 }

--- a/forrest.go
+++ b/forrest.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 //Forest represents a collection of decision trees grown to predict Target.
 type Forest struct {
 	//Forest string
@@ -29,21 +27,8 @@ itter indicates weather to use iterative splitting for all categorical features 
 with more then 6 categories.
 */
 
-func GrowRandomForest(fm *FeatureMatrix,
-	target Target,
-	candidates []int,
-	nSamples int,
-	mTry int,
-	nTrees int,
-	leafSize int,
-	maxDepth int,
-	splitmissing bool,
-	force bool,
-	vet bool,
-	evaloob bool,
-	importance *[]*RunningMean) (f *Forest) {
-
-	f = &Forest{target.GetName(), make([]*Tree, 0, nTrees), 0.0}
+func GrowRandomForest(fm *FeatureMatrix, target Target, candidates []int, nSamples int, mTry int, nTrees int, leafSize int, maxDepth int, splitmissing bool, force bool, vet bool, evaloob bool, importance *[]*RunningMean) *Forest {
+	f := &Forest{target.GetName(), make([]*Tree, 0, nTrees), 0.0}
 
 	switch target.(type) {
 	case TargetWithIntercept:
@@ -57,7 +42,10 @@ func GrowRandomForest(fm *FeatureMatrix,
 		nCases := fm.Data[0].Length()
 		cases := SampleWithReplacment(nSamples, nCases)
 
-		f.Trees = append(f.Trees, NewTree())
+		tree := NewTree()
+		tree.Target = target.GetName()
+		f.Trees = append(f.Trees, tree)
+
 		f.Trees[i].Grow(fm, target, cases, candidates, nil, mTry, leafSize, maxDepth, splitmissing, force, vet, evaloob, false, importance, nil, allocs)
 		switch target.(type) {
 		case BoostingTarget:
@@ -65,5 +53,5 @@ func GrowRandomForest(fm *FeatureMatrix,
 			f.Trees[i].Weight = target.(BoostingTarget).Boost(ls, ps)
 		}
 	}
-	return
+	return f
 }

--- a/gradboosttarget.go
+++ b/gradboosttarget.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 /*
 GradBoostTarget wraps a numerical feature as a target for us in Gradiant Boosting Trees.
 

--- a/growforest/growforest.go
+++ b/growforest/growforest.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/ryanbressler/CloudForest"
-	"github.com/ryanbressler/CloudForest/stats"
 	"io"
 	"log"
 	"math"
@@ -17,6 +15,9 @@ import (
 	"runtime/pprof"
 	"sync"
 	"time"
+
+	"github.com/lytics/CloudForest"
+	"github.com/lytics/CloudForest/stats"
 )
 
 func main() {

--- a/leafcount/leafcount.go
+++ b/leafcount/leafcount.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/ryanbressler/CloudForest"
 	"log"
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/lytics/CloudForest"
 )
 
 func main() {

--- a/node.go
+++ b/node.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 //Recursable defines a function signature for functions that can be called at every
 //down stream node of a tree as Node.Recurse recurses up the tree. The function should
 //have two parameters, the current node and an array of ints specifying the cases that

--- a/numadaboostingtarget.go
+++ b/numadaboostingtarget.go
@@ -18,7 +18,7 @@ func NewNumAdaBoostTarget(f NumFeature) (abt *NumAdaBoostTarget) {
 	nCases := f.Length()
 	abt = &NumAdaBoostTarget{f, make([]float64, nCases), 0.0}
 	cases := make([]int, nCases)
-	for i, _ := range abt.Weights {
+	for i := range abt.Weights {
 		abt.Weights[i] = 1 / float64(nCases)
 		cases[i] = i
 	}

--- a/regrettarget.go
+++ b/regrettarget.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 /*
 RegretTarget wraps a categorical feature for use in regret driven classification.
 The ith entry in costs should contain the cost of misclassifying a case that actually

--- a/sklearn_tree.go
+++ b/sklearn_tree.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 // ScikitNode
 // cdef struct Node:
 //     # Base storage structure for the nodes in a Tree object

--- a/sortby/sortby.go
+++ b/sortby/sortby.go
@@ -4,8 +4,6 @@ of floats as needed in random forest training. It is about 30-40% faster then th
 standard sort.*/
 package sortby
 
-import ()
-
 //SortBy will sort the values in cases and vals by the values in vals in increasing order.
 //If vals is longer then cases only the coresponding section will be sorted.
 func SortBy(cases *[]int, vals *[]float64) {

--- a/splitallocations.go
+++ b/splitallocations.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 //BestSplitAllocs contains reusable allocations for split searching and evaluation.
 //Seprate instances should be used in each go routing doing learning.
 type BestSplitAllocs struct {

--- a/splitter.go
+++ b/splitter.go
@@ -1,8 +1,6 @@
 package CloudForest
 
-import (
 //"fmt"
-)
 
 //Splitter contains fields that can be used to cases by a single feature. The split
 //can be either numerical in which case it is defined by the Value field or

--- a/transduction.go
+++ b/transduction.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 /*
 TransTarget is used for semi supervised transduction trees [1] that balance compine supervised impurity with
 a purelly density based term.

--- a/tree.go
+++ b/tree.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 type nodeAndCases struct {
 	n          *Node
 	start      int
@@ -194,12 +192,12 @@ func (t *Tree) GrowJungle(fm *FeatureMatrix,
 
 	//var innercanidates []int
 	var impDec float64
-	nodes := []nodeAndCases{nodeAndCases{t.Root, 0, len(cases), 0, nil, false}}
+	nodes := []nodeAndCases{{t.Root, 0, len(cases), 0, nil, false}}
 	var depth, nconstants, start, end, fi, firstThisLevel int
 	var split interface{}
 
-	innercases := cases[0:len(cases)]
-	innercases2 := cases[0:len(cases)]
+	innercases := cases[0:]
+	innercases2 := cases[0:]
 
 	for {
 		//Extend Nodes

--- a/utils/nfold/main.go
+++ b/utils/nfold/main.go
@@ -4,10 +4,11 @@ import (
 	"encoding/csv"
 	"flag"
 	"fmt"
-	"github.com/ryanbressler/CloudForest"
 	"io"
 	"log"
 	"os"
+
+	"github.com/lytics/CloudForest"
 )
 
 func openfiles(trainfn string, testfn string) (trainW io.WriteCloser, testW io.WriteCloser) {

--- a/utils/toafm/main.go
+++ b/utils/toafm/main.go
@@ -4,11 +4,12 @@ import (
 	"encoding/csv"
 	"flag"
 	"fmt"
-	"github.com/ryanbressler/CloudForest"
 	"io"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/lytics/CloudForest"
 )
 
 func main() {

--- a/voter.go
+++ b/voter.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 //VoteTallyer  is used to tabulate votes by trees and is implemented by feature type specific
 //structs like NumBallotBox and CatBallotBox.
 //Vote should register a cote that casei should be predicted as pred.


### PR DESCRIPTION
a couple of minor things: 
- `Parse` numeric fields by default, instead of categorical 
- assigns a `target` field to the trees in the `GrowRandomForest` function
- runs `gofmt -s -w .` on codebase
