### PR TITLE
use lytics package throughout

### DIFF
--- a/sortablefeature.go
+++ b/sortablefeature.go
@@ -1,10 +1,7 @@
 package CloudForest
 
 import (
-	//"fmt"
-	//"math"
-	"github.com/ryanbressler/CloudForest/sortby"
-	//"sort"
+	"github.com/lytics/CloudForest/sortby"
 )
 
 /*SortableFeature is a wrapper for a feature and set of cases that satisfies the


### PR DESCRIPTION
converted all occurrences of `github.com/ryanbressler/CloudForest` to `github.com/lytics/CloudForest` in a previous commit, but I missed one
