### PR TITLE
keep correct name when 1-hot encoding

### DIFF
--- a/featurematrix.go
+++ b/featurematrix.go
@@ -89,12 +89,12 @@ func (fm *FeatureMatrix) OneHot() *FeatureMatrix {
 	for _, f := range fm.Data {
 		switch f.(type) {
 		case NumFeature:
-			out.Map[f.GetName()] = len(out.Map)
+			out.Map["N:"+f.GetName()] = len(out.Map)
 			out.Data = append(out.Data, f)
 		case CatFeature:
 			fns := f.(CatFeature).OneHot()
 			for _, fn := range fns {
-				out.Map[fn.GetName()] = len(out.Map)
+				out.Map["C:"+fn.GetName()] = len(out.Map)
 				out.Data = append(out.Data, fn)
 			}
 		}


### PR DESCRIPTION
keep 1-hot encoded feature names consistent
