### PR TITLE
Lock CatMap before access. 

### DIFF
--- a/applyforest/applyforest.go
+++ b/applyforest/applyforest.go
@@ -128,7 +128,7 @@ func main() {
 
 			for j := range cbb.CatMap.Back {
 				total := 0.0
-				total = box.Map[j]
+				total = box.Cat[j]
 
 				fmt.Fprintf(votefile, "\t%v", total)
 

--- a/applyforest/applyforest.go
+++ b/applyforest/applyforest.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/lytics/CloudForest"
+	"github.com/glycerine/CloudForest"
 )
 
 func main() {

--- a/arff.go
+++ b/arff.go
@@ -45,8 +45,7 @@ func ParseARFF(input io.Reader) *FeatureMatrix {
 					false})
 			} else {
 				data = append(data, &DenseCatFeature{
-					&CatMap{make(map[string]int, 0),
-						make([]string, 0, 0)},
+					NewCatMap(),
 					make([]int, 0, 0),
 					make([]bool, 0, 0),
 					vals[1],

--- a/catballotbox.go
+++ b/catballotbox.go
@@ -41,9 +41,9 @@ type CatBallotBox struct {
 //NewCatBallotBox builds a new ballot box for the number of cases specified by "size".
 func NewCatBallotBox(size int) *CatBallotBox {
 	bb := CatBallotBox{
-		&CatMap{make(map[string]int),
-			make([]string, 0, 0)},
-		make([]*CatBallot, 0, size)}
+		CatMap: NewCatMap(),
+		Box:    make([]*CatBallot, 0, size),
+	}
 	for i := 0; i < size; i++ {
 		bb.Box = append(bb.Box, NewCatBallot())
 	}

--- a/densecatfeature.go
+++ b/densecatfeature.go
@@ -25,10 +25,7 @@ type DenseCatFeature struct {
 
 func NewDenseCatFeature(name string) *DenseCatFeature {
 	return &DenseCatFeature{
-		CatMap: &CatMap{
-			Map:  make(map[string]int, 0),
-			Back: make([]string, 0, 0),
-		},
+		CatMap:       NewCatMap(),
 		CatData:      make([]int, 0, 0),
 		Missing:      make([]bool, 0, 0),
 		Name:         name,
@@ -74,10 +71,12 @@ func (f *DenseCatFeature) OneHot() (fs []Feature) {
 	l := f.Length()
 	if f.NCats() > 2 {
 		fs = make([]Feature, 0, f.NCats())
+		f.CatMapMut.Lock()
+		defer f.CatMapMut.Unlock()
 		for j, sv := range f.Back {
 			fn := &DenseCatFeature{
-				&CatMap{map[string]int{"false": 0, "true": 1},
-					[]string{"false", "true"}},
+				&CatMap{privateMap: map[string]int{"false": 0, "true": 1},
+					Back: []string{"false", "true"}},
 				make([]int, l, l),
 				f.Missing,
 				f.Name + "==" + sv,
@@ -1209,14 +1208,14 @@ func (f *DenseCatFeature) ShuffledCopy() Feature {
 /*Copy returns a copy of f.*/
 func (f *DenseCatFeature) Copy() Feature {
 	capacity := len(f.Missing)
+
 	fake := &DenseCatFeature{
-		&CatMap{f.Map,
-			f.Back},
-		nil,
-		make([]bool, capacity),
-		f.Name,
-		f.RandomSearch,
-		f.HasMissing}
+		CatMap:       f.CopyCatMap(),
+		CatData:      nil,
+		Missing:      make([]bool, capacity),
+		Name:         f.Name,
+		RandomSearch: f.RandomSearch,
+		HasMissing:   f.HasMissing}
 
 	copy(fake.Missing, f.Missing)
 

--- a/densecatfeature_test.go
+++ b/densecatfeature_test.go
@@ -13,8 +13,7 @@ func TestCatFeature(t *testing.T) {
 	name := "catfeature"
 
 	f := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		name,
@@ -157,8 +156,7 @@ func TestCatFeature(t *testing.T) {
 	}
 
 	mediumf := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		"mediumf",
@@ -207,8 +205,7 @@ func TestCatFeature(t *testing.T) {
 func TestBigCatFeature(t *testing.T) {
 
 	bigf := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		"big",
@@ -216,8 +213,7 @@ func TestBigCatFeature(t *testing.T) {
 		false}
 
 	boolf := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		"bool",

--- a/featurematrix.go
+++ b/featurematrix.go
@@ -49,13 +49,13 @@ func (fm *FeatureMatrix) StripStrings(target string) {
 		case *DenseCatFeature:
 			name := fmt.Sprintf("C:%v", i)
 			fm.Map[name] = i
-			f.(*DenseCatFeature).Name = name
-			f.(*DenseCatFeature).Map = make(map[string]int)
-			for j, v := range f.(*DenseCatFeature).Back {
+			dcf := f.(*DenseCatFeature)
+			dcf.Name = name
+			dcf.privateMap = make(map[string]int)
+			for j, v := range dcf.Back {
 				v = fmt.Sprintf("%v", j)
-				f.(*DenseCatFeature).Back[j] = v
-				f.(*DenseCatFeature).Map[v] = i
-
+				dcf.Back[j] = v
+				dcf.privateMap[v] = i
 			}
 
 		}
@@ -477,8 +477,7 @@ func Parse(input io.Reader, sep rune) *FeatureMatrix {
 						false})
 				} else {
 					data = append(data, &DenseCatFeature{
-						&CatMap{make(map[string]int, 0),
-							make([]string, 0, 0)},
+						NewCatMap(),
 						make([]int, 0, 0),
 						make([]bool, 0, 0),
 						label,
@@ -554,8 +553,7 @@ func ParseFeature(record []string) Feature {
 	switch record[0][0:2] {
 	case "C:":
 		f := &DenseCatFeature{
-			&CatMap{make(map[string]int, 0),
-				make([]string, 0, 0)},
+			NewCatMap(),
 			nil,
 			make([]bool, 0, capacity),
 			record[0],

--- a/growforest/growforest.go
+++ b/growforest/growforest.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lytics/CloudForest"
-	"github.com/lytics/CloudForest/stats"
+	"github.com/glycerine/CloudForest"
+	"github.com/glycerine/CloudForest/stats"
 )
 
 func main() {

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 go install github.com/glycerine/CloudForest/growforest
 go install github.com/glycerine/CloudForest/applyforest
 go install github.com/glycerine/CloudForest/leafcount

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 go install github.com/glycerine/CloudForest/growforest
 go install github.com/glycerine/CloudForest/applyforest
 go install github.com/glycerine/CloudForest/leafcount

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,7 @@
-go install github.com/ryanbressler/CloudForest/growforest
-go install github.com/ryanbressler/CloudForest/applyforest
-go install github.com/ryanbressler/CloudForest/leafcount
+go install github.com/glycerine/CloudForest/growforest
+go install github.com/glycerine/CloudForest/applyforest
+go install github.com/glycerine/CloudForest/leafcount
+
+go install github.com/glycerine/CloudForest/leafcount
+go install github.com/glycerine/CloudForest/utils/nfold
+go install github.com/glycerine/CloudForest/utils/toafm

--- a/leafcount/leafcount.go
+++ b/leafcount/leafcount.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/lytics/CloudForest"
+	"github.com/glycerine/CloudForest"
 )
 
 func main() {

--- a/libsvm.go
+++ b/libsvm.go
@@ -46,8 +46,7 @@ func ParseLibSVM(input io.Reader) *FeatureMatrix {
 			} else {
 				//doesn't look like a float...add dense catagorical
 				data = append(data, &DenseCatFeature{
-					&CatMap{make(map[string]int, 0),
-						make([]string, 0, 0)},
+					NewCatMap(),
 					make([]int, 0, 0),
 					make([]bool, 0, 0),
 					name,

--- a/sortablefeature.go
+++ b/sortablefeature.go
@@ -1,7 +1,7 @@
 package CloudForest
 
 import (
-	"github.com/lytics/CloudForest/sortby"
+	"github.com/glycerine/CloudForest/sortby"
 )
 
 /*SortableFeature is a wrapper for a feature and set of cases that satisfies the

--- a/utils/nfold/main.go
+++ b/utils/nfold/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/lytics/CloudForest"
+	"github.com/glycerine/CloudForest"
 )
 
 func openfiles(trainfn string, testfn string) (trainW io.WriteCloser, testW io.WriteCloser) {

--- a/utils/toafm/main.go
+++ b/utils/toafm/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/lytics/CloudForest"
+	"github.com/glycerine/CloudForest"
 )
 
 func main() {

--- a/wrappers/python/CFClassifier.py
+++ b/wrappers/python/CFClassifier.py
@@ -8,7 +8,7 @@ calls to cloudforests growforest and applyforest utilities to be called as a sci
 classifier.
 
 It works via writting uuid identified temp files to disk in the current working directory so
-it has more overhead then a pure in memory implementation but handle problems where the 
+it has more overhead then a pure in memory implementation but handle problems where the
 model is too large to fit in system memory.
 """
 
@@ -43,9 +43,9 @@ def writearff(fo, df, target="", unique=[]):
 
 		if target!="" and col == target:
 			coltype = "{%(values)s}"%{"values":",".join([str(v) for v in unique])}
-		
 
-		
+
+
 
 		fo.write("@ATTRIBUTE %(name)s %(type)s\n"%{"name":col,"type":coltype})
 
@@ -53,31 +53,34 @@ def writearff(fo, df, target="", unique=[]):
 	df.to_csv(fo, na_rep="NA", index=False, header=False)
 
 class CFClassifier:
-	"""CFClassifier wraps command line calls to cloudforest's growforest 
+    """CFClassifier wraps command line calls to cloudforest's growforest
 	and applyforest for use as a scikit-learn Classifier. It will write
 	temporary files to your workding directory."""
 
 	options = ""
 
 
-	def __init__(self, optionstring):
+    def __init__(self, optionstring):
 		self.options = optionstring
 		self.uuid = uuid.uuid1()
-	
-	def fit(self, X, y):
+
+    def fit(self, X, y):
 		df = pd.DataFrame(X).copy()
 		target = "%(uuid)s.target"%{"uuid":self.uuid}
 		fn = "%(uuid)s.train.cloudforest.arff"%{"uuid":self.uuid}
 		self.forest = "%(uuid)s.forest.cloudforest.sf"%{"uuid":self.uuid}
 
-		
+
 		self.unique = np.unique(y)
 
 		#print y
-		df[target] = np.array(y,dtype=bool)
+        if len(self.unique) == 2:
+    		df[target] = np.array(y,dtype=bool)
+        else:
+            df[target] = np.array(y)
 		#print df[target]
-		
-		
+
+
 		fo = open(fn,"w")
 		writearff(fo,df,target,self.unique)
 		fo.close()
@@ -91,11 +94,11 @@ class CFClassifier:
 
 		subprocess.call(invocation, shell=True)
 
-	def predict(self, X):
+    def predict(self, X):
 		df = pd.DataFrame(X)
 		fn = "%(uuid)s.test.cloudforest.arff"%{"uuid":self.uuid}
 		preds = "%(uuid)s.preds.cloudforest.tsv"%{"uuid":self.uuid}
-		
+
 		fo = open(fn,"w")
 		writearff(fo,df)
 		fo.close()
@@ -115,12 +118,12 @@ class CFClassifier:
 
 		return np.array(predictions,dtype=int)
 
-	def predict_proba(self, X):
+    def predict_proba(self, X):
 		df = pd.DataFrame(X)
 		fn = "%(uuid)s.test.cloudforest.arff"%{"uuid":self.uuid}
 		votes = "%(uuid)s.votes.cloudforest.tsv"%{"uuid":self.uuid}
-		
-		
+
+
 		fo = open(fn,"w")
 		writearff(fo,df)
 		fo.close()
@@ -138,7 +141,7 @@ class CFClassifier:
 		header = 0
 		votes = 0
 
-		
+
 		line = fo.next()
 		vs = line.split()[1:]
 		if vs[0]=="True" or vs[0]=="False":
@@ -164,3 +167,7 @@ class CFClassifier:
 
 		return np.dstack(probs)[0]
 
+    def	score(self,	X,	Y):
+        preds	=	self.predict(X)
+        predicted_ratio	=	float(np.sum(preds==Y))/float(len(Y))
+        return	predicted_ratio


### PR DESCRIPTION
Add sync.Lock() and Unlock() around reads and writes to the CatMap. Also add full copying that may reduce contention.

Fixes #20 