### PR TITLE
sync CatMap to avoid concurrent map access.

### DIFF
--- a/arff.go
+++ b/arff.go
@@ -45,8 +45,7 @@ func ParseARFF(input io.Reader) *FeatureMatrix {
 					false})
 			} else {
 				data = append(data, &DenseCatFeature{
-					&CatMap{make(map[string]int, 0),
-						make([]string, 0, 0)},
+					NewCatMap(),
 					make([]int, 0, 0),
 					make([]bool, 0, 0),
 					vals[1],

--- a/catballotbox.go
+++ b/catballotbox.go
@@ -27,8 +27,7 @@ type CatBallotBox struct {
 //NewCatBallotBox builds a new ballot box for the number of cases specified by "size".
 func NewCatBallotBox(size int) *CatBallotBox {
 	bb := CatBallotBox{
-		&CatMap{make(map[string]int),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]*CatBallot, 0, size)}
 	for i := 0; i < size; i++ {
 		bb.Box = append(bb.Box, NewCatBallot())

--- a/densecatfeature.go
+++ b/densecatfeature.go
@@ -25,10 +25,7 @@ type DenseCatFeature struct {
 
 func NewDenseCatFeature(name string) *DenseCatFeature {
 	return &DenseCatFeature{
-		CatMap: &CatMap{
-			Map:  make(map[string]int, 0),
-			Back: make([]string, 0, 0),
-		},
+		CatMap:       NewCatMap(),
 		CatData:      make([]int, 0, 0),
 		Missing:      make([]bool, 0, 0),
 		Name:         name,
@@ -74,10 +71,12 @@ func (f *DenseCatFeature) OneHot() (fs []Feature) {
 	l := f.Length()
 	if f.NCats() > 2 {
 		fs = make([]Feature, 0, f.NCats())
+		f.CatMapMut.Lock()
+		defer f.CatMapMut.Unlock()
 		for j, sv := range f.Back {
 			fn := &DenseCatFeature{
-				&CatMap{map[string]int{"false": 0, "true": 1},
-					[]string{"false", "true"}},
+				&CatMap{privateMap: map[string]int{"false": 0, "true": 1},
+					Back: []string{"false", "true"}},
 				make([]int, l, l),
 				f.Missing,
 				f.Name + "==" + sv,
@@ -1209,14 +1208,14 @@ func (f *DenseCatFeature) ShuffledCopy() Feature {
 /*Copy returns a copy of f.*/
 func (f *DenseCatFeature) Copy() Feature {
 	capacity := len(f.Missing)
+
 	fake := &DenseCatFeature{
-		&CatMap{f.Map,
-			f.Back},
-		nil,
-		make([]bool, capacity),
-		f.Name,
-		f.RandomSearch,
-		f.HasMissing}
+		CatMap:       f.CopyCatMap(),
+		CatData:      nil,
+		Missing:      make([]bool, capacity),
+		Name:         f.Name,
+		RandomSearch: f.RandomSearch,
+		HasMissing:   f.HasMissing}
 
 	copy(fake.Missing, f.Missing)
 

--- a/densecatfeature_test.go
+++ b/densecatfeature_test.go
@@ -13,8 +13,7 @@ func TestCatFeature(t *testing.T) {
 	name := "catfeature"
 
 	f := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		name,
@@ -157,8 +156,7 @@ func TestCatFeature(t *testing.T) {
 	}
 
 	mediumf := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		"mediumf",
@@ -207,8 +205,7 @@ func TestCatFeature(t *testing.T) {
 func TestBigCatFeature(t *testing.T) {
 
 	bigf := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		"big",
@@ -216,8 +213,7 @@ func TestBigCatFeature(t *testing.T) {
 		false}
 
 	boolf := &DenseCatFeature{
-		&CatMap{make(map[string]int, 0),
-			make([]string, 0, 0)},
+		NewCatMap(),
 		make([]int, 0, 0),
 		make([]bool, 0, 0),
 		"bool",

--- a/featurematrix.go
+++ b/featurematrix.go
@@ -49,13 +49,13 @@ func (fm *FeatureMatrix) StripStrings(target string) {
 		case *DenseCatFeature:
 			name := fmt.Sprintf("C:%v", i)
 			fm.Map[name] = i
-			f.(*DenseCatFeature).Name = name
-			f.(*DenseCatFeature).Map = make(map[string]int)
-			for j, v := range f.(*DenseCatFeature).Back {
+			dcf := f.(*DenseCatFeature)
+			dcf.Name = name
+			dcf.privateMap = make(map[string]int)
+			for j, v := range dcf.Back {
 				v = fmt.Sprintf("%v", j)
-				f.(*DenseCatFeature).Back[j] = v
-				f.(*DenseCatFeature).Map[v] = i
-
+				dcf.Back[j] = v
+				dcf.privateMap[v] = i
 			}
 
 		}
@@ -477,8 +477,7 @@ func Parse(input io.Reader, sep rune) *FeatureMatrix {
 						false})
 				} else {
 					data = append(data, &DenseCatFeature{
-						&CatMap{make(map[string]int, 0),
-							make([]string, 0, 0)},
+						NewCatMap(),
 						make([]int, 0, 0),
 						make([]bool, 0, 0),
 						label,
@@ -554,8 +553,7 @@ func ParseFeature(record []string) Feature {
 	switch record[0][0:2] {
 	case "C:":
 		f := &DenseCatFeature{
-			&CatMap{make(map[string]int, 0),
-				make([]string, 0, 0)},
+			NewCatMap(),
 			nil,
 			make([]bool, 0, capacity),
 			record[0],

--- a/libsvm.go
+++ b/libsvm.go
@@ -46,8 +46,7 @@ func ParseLibSVM(input io.Reader) *FeatureMatrix {
 			} else {
 				//doesn't look like a float...add dense catagorical
 				data = append(data, &DenseCatFeature{
-					&CatMap{make(map[string]int, 0),
-						make([]string, 0, 0)},
+					NewCatMap(),
 					make([]int, 0, 0),
 					make([]bool, 0, 0),
 					name,


### PR DESCRIPTION
Add sync.Lock() and sync.Unlock() around reads and writes to the CatMap. 
Also add full copying of the CatMap instead of sharing. That may reduce contention.

Fixes #20